### PR TITLE
Unify class names into IYawRotatable format

### DIFF
--- a/src/main/java/xyz/fmdc/arw/baseclass/modelblock/ModelNormalModelBase.kt
+++ b/src/main/java/xyz/fmdc/arw/baseclass/modelblock/ModelNormalModelBase.kt
@@ -8,6 +8,7 @@ import net.minecraftforge.client.model.AdvancedModelLoader
 import net.minecraftforge.client.model.IModelCustom
 import org.lwjgl.opengl.GL11
 import xyz.fmdc.arw.baseclass.IParallelModelLoad
+import xyz.fmdc.arw.baseclass.module.direction.IDirection
 
 abstract class ModelNormalModelBase<T : TileEntity> : ModelBase(), IParallelModelLoad {
     abstract val modelName: ResourceLocation
@@ -29,7 +30,16 @@ abstract class ModelNormalModelBase<T : TileEntity> : ModelBase(), IParallelMode
         GL11.glTranslated(x + 0.5, y, z + 0.5)
 
         FMLClientHandler.instance().client.renderEngine.bindTexture(texture)
-        renderBase()
+
+        if (tile is IDirection) {
+            val directionYaw = tile.getDirectionAngle()
+            GL11.glRotated(-directionYaw, 0.0, 1.0, 0.0)
+            renderBase()
+            GL11.glRotated(+directionYaw, 0.0, 1.0, 0.0)
+        } else {
+            renderBase()
+        }
+
 
         GL11.glPopMatrix()
     }

--- a/src/main/java/xyz/fmdc/arw/baseclass/modelblock/ModelNormalRotatableModelBase.kt
+++ b/src/main/java/xyz/fmdc/arw/baseclass/modelblock/ModelNormalRotatableModelBase.kt
@@ -29,7 +29,6 @@ abstract class ModelNormalRotatableModelBase<T : TileEntity> : ModelNormalModelB
     override fun render(tile: T, x: Double, y: Double, z: Double) {
         GL11.glPushMatrix()
         GL11.glTranslated(x + 0.5, y, z + 0.5)
-        //GL11.glScaled(100.0, 100.0, 100.0)
 
         FMLClientHandler.instance().client.renderEngine.bindTexture(texture)
 

--- a/src/main/java/xyz/fmdc/arw/baseclass/modelblock/ModelNormalTileEntity.kt
+++ b/src/main/java/xyz/fmdc/arw/baseclass/modelblock/ModelNormalTileEntity.kt
@@ -9,10 +9,13 @@ import net.minecraft.network.play.server.S35PacketUpdateTileEntity
 import net.minecraft.tileentity.TileEntity
 import net.minecraft.util.AxisAlignedBB
 import xyz.fmdc.arw.baseclass.module.direction.IDirection
+import xyz.fmdc.arw.baseclass.module.direction.ModuleDirection
 import xyz.fmdc.arw.loadTo
 import xyz.fmdc.arw.newPacketUpdateTileEntity
 
 open class ModelNormalTileEntity : TileEntity(), IDirection {
+    override val moduleDirection = ModuleDirection()
+
     private val strDirectionAngDeg = "directionAngDeg"
 
     override fun readFromNBT(nbt: NBTTagCompound) {
@@ -27,6 +30,9 @@ open class ModelNormalTileEntity : TileEntity(), IDirection {
 
     @SideOnly(Side.CLIENT)
     override fun getRenderBoundingBox(): AxisAlignedBB {
+        if (this.blockType == null) {
+            return super.getRenderBoundingBox()
+        }
         val blockType = this.blockType as ModelNormalBlockContainer
         val selectBoundsHalfWide = blockType.selectBoundsHalfWide + 1
         val selectBoundsHeight = blockType.selectBoundsHeight + 1

--- a/src/main/java/xyz/fmdc/arw/baseclass/modelblock/ModelNormalYawPitchRotatableTileEntity.kt
+++ b/src/main/java/xyz/fmdc/arw/baseclass/modelblock/ModelNormalYawPitchRotatableTileEntity.kt
@@ -3,7 +3,7 @@ package xyz.fmdc.arw.baseclass.modelblock
 import net.minecraft.nbt.NBTTagCompound
 import xyz.fmdc.arw.baseclass.module.rotatable.*
 
-open class ModelNormalRotatableYawPitchTileEntity : ModelNormalTileEntity(), IRotatableYawPitch {
+open class ModelNormalYawPitchRotatableTileEntity : ModelNormalTileEntity(), IYawPitchRotatable {
     override val moduleYawRotatable = ModuleYawRotatable()
     override val modulePitchRotatable = ModulePitchRotatable()
 

--- a/src/main/java/xyz/fmdc/arw/baseclass/modelblock/ModelNormalYawRotatableTileEntity.kt
+++ b/src/main/java/xyz/fmdc/arw/baseclass/modelblock/ModelNormalYawRotatableTileEntity.kt
@@ -1,0 +1,22 @@
+package xyz.fmdc.arw.baseclass.modelblock
+
+import net.minecraft.nbt.NBTTagCompound
+import xyz.fmdc.arw.baseclass.module.rotatable.IYawRotatable
+import xyz.fmdc.arw.baseclass.module.rotatable.ModuleYawRotatable
+import xyz.fmdc.arw.baseclass.module.rotatable.yawDeg
+
+open class ModelNormalYawRotatableTileEntity : ModelNormalTileEntity(), IYawRotatable {
+    override val moduleYawRotatable = ModuleYawRotatable()
+
+    private val strYawDeg = "yawDeg"
+
+    override fun readFromNBT(nbt: NBTTagCompound) {
+        super.readFromNBT(nbt)
+        this.yawDeg = nbt.getDouble(strYawDeg)
+    }
+
+    override fun writeToNBT(nbt: NBTTagCompound) {
+        super.writeToNBT(nbt)
+        nbt.setDouble(strYawDeg, this.yawDeg)
+    }
+}

--- a/src/main/java/xyz/fmdc/arw/baseclass/module/direction/IDirection.kt
+++ b/src/main/java/xyz/fmdc/arw/baseclass/module/direction/IDirection.kt
@@ -5,6 +5,8 @@ import xyz.fmdc.arw.getFacingFromAngle
 import xyz.fmdc.arw.getHorizontalAngle
 
 interface IDirection {
+    val moduleDirection: ModuleDirection
+
     fun saveReversDirectionData(angDeg: Float) {
         saveReversDirectionData(angDeg.toDouble())
     }
@@ -26,9 +28,8 @@ interface IDirection {
     }
 }
 
-private var backingFacing: EnumFacing = EnumFacing.UP
 var IDirection.facing: EnumFacing
-    get() = backingFacing
+    get() = moduleDirection.facing
     set(value) {
-        backingFacing = value
+        moduleDirection.facing = value
     }

--- a/src/main/java/xyz/fmdc/arw/baseclass/module/direction/ModuleDirection.kt
+++ b/src/main/java/xyz/fmdc/arw/baseclass/module/direction/ModuleDirection.kt
@@ -1,0 +1,7 @@
+package xyz.fmdc.arw.baseclass.module.direction
+
+import net.minecraft.util.EnumFacing
+
+class ModuleDirection {
+    var facing: EnumFacing = EnumFacing.UP
+}

--- a/src/main/java/xyz/fmdc/arw/baseclass/module/rotatable/IYawPitchRotatable.kt
+++ b/src/main/java/xyz/fmdc/arw/baseclass/module/rotatable/IYawPitchRotatable.kt
@@ -2,7 +2,7 @@ package xyz.fmdc.arw.baseclass.module.rotatable
 
 import xyz.fmdc.arw.network.PacketHandlerARW
 
-interface IRotatableYawPitch : IYawRotatable, IPitchRotatable {
+interface IYawPitchRotatable : IYawRotatable, IPitchRotatable {
     override fun syncAngleToClient() {
         PacketHandlerARW.sendPacketAll(SyncAngleMessage(yawDeg, pitchDeg))
     }

--- a/src/main/java/xyz/fmdc/arw/baseclass/module/rotatable/SyncAngleMessage.kt
+++ b/src/main/java/xyz/fmdc/arw/baseclass/module/rotatable/SyncAngleMessage.kt
@@ -25,7 +25,7 @@ class SyncAngleMessage(var yawDeg: Double, var pitchDeg: Double) : TileEntityMes
             if (tile is IYawRotatable) {
                 tile.yawDeg = message.yawDeg
             }
-            if (tile is IRotatableYawPitch) {
+            if (tile is IYawPitchRotatable) {
                 tile.pitchDeg = message.pitchDeg
             }
             if (ctx.side.isServer) {

--- a/src/main/java/xyz/fmdc/arw/spg62/SPG62Tile.kt
+++ b/src/main/java/xyz/fmdc/arw/spg62/SPG62Tile.kt
@@ -1,8 +1,8 @@
 package xyz.fmdc.arw.spg62
 
-import xyz.fmdc.arw.baseclass.modelblock.ModelNormalRotatableYawPitchTileEntity
+import xyz.fmdc.arw.baseclass.modelblock.ModelNormalYawPitchRotatableTileEntity
 
-class SPG62Tile : ModelNormalRotatableYawPitchTileEntity() {
+class SPG62Tile : ModelNormalYawPitchRotatableTileEntity() {
     override fun getDefaultPitchDeg(): Double {
         return 45.0
     }


### PR DESCRIPTION
クラス名が"Rotatable Yaw"のママになっているものを修正。IDirectionでModuleが使われておらずブロックごとのデータ保存ができていなかったのを修正。